### PR TITLE
Finish normalizing return value of get_transaction() in network APIs

### DIFF
--- a/bitsv/network/transaction.py
+++ b/bitsv/network/transaction.py
@@ -27,9 +27,9 @@ class Transaction:
         return 'Transaction(txid={}, amount_in={}, amount_out={}, ' \
                'fee={}, inputs={}, outputs={})'.format(
                 repr(self.txid),
-                repr(self.amount_in),
-                repr(self.amount_out),
-                repr(self.fee),
+                str(self.amount_in),
+                str(self.amount_out),
+                str(self.fee),
                 len(self.inputs),
                 len(self.outputs))
 


### PR DESCRIPTION
This normalizes the return value of get_transaction() in BitIndex3 to match BCHSVExplorerAPI

If you merge this into your branch it should propagate across to the PR... https://github.com/AustEcon/bitsv/pull/42

Still need to add a test to ensure ^^ (return values match)... to prevent future regressions... but can do that later.

So you could either merge this in here to include it in the PR (if you think it is okay??) or otherwise I can just add this commit in as a patch after the PR is merged... either way, I'm happy. 😃 